### PR TITLE
Remove filter from emitter/receiver

### DIFF
--- a/UsefulCombinators_0.3.8/control.lua
+++ b/UsefulCombinators_0.3.8/control.lua
@@ -1574,18 +1574,19 @@ classes["receiver-combinator"] = {
         local slots = {}
         local p1 = object.meta.signal
         if control.enabled then
-          local sender
+          local senders = {}
           for k,v in pairs(data["emitter-combinator"]) do
             if v.meta.params[1] and (p1.name == v.meta.params[1].signal.name) then
-              sender = v.meta
-              break;
+              table.insert(senders, v.meta)
             end
           end
-          if sender then
-            local sender_control = sender.entity.get_control_behavior()
-            for i = 2,6 do
-              if sender.params[i].signal and sender.params[i].signal.name then
-                table.insert(slots, {signal = sender.params[i].signal, count = sender.params[i].count, index = (i - 1)})
+          if next(senders) ~= nil then
+            for _,sender in pairs(senders)
+              local sender_control = sender.entity.get_control_behavior()
+              for i = 2,6 do
+                if sender.params[i].signal and sender.params[i].signal.name then
+                  table.insert(slots, {signal = sender.params[i].signal, count = sender.params[i].count, index = (i - 1)})
+                end
               end
             end
           end

--- a/UsefulCombinators_0.3.8/control.lua
+++ b/UsefulCombinators_0.3.8/control.lua
@@ -1581,7 +1581,7 @@ classes["receiver-combinator"] = {
             end
           end
           if next(senders) ~= nil then
-            for _,sender in pairs(senders)
+            for _,sender in pairs(senders) do
               local sender_control = sender.entity.get_control_behavior()
               for i = 2,6 do
                 if sender.params[i].signal and sender.params[i].signal.name then

--- a/UsefulCombinators_0.3.8/prototypes/categories/usefulcombinators.lua
+++ b/UsefulCombinators_0.3.8/prototypes/categories/usefulcombinators.lua
@@ -6,7 +6,7 @@ data:extend(
 		order = "u",
 		inventory_order = "u",
 		icon = "__UsefulCombinators__/graphics/icons/clock.png",
-    icon_size = 64
+   		icon_size = 64
 	},
   {
 		type = "item-subgroup",


### PR DESCRIPTION
I propose this evolution.

This is tested and work properly.

I think emitter and receiver shouldn't do anything else than broadcast and receive.
By removing filter from the emitter entity we can have as many emitter as we want on the same channel with any kind of items.

What do you think about this ?